### PR TITLE
Add security headers and merge htaccess

### DIFF
--- a/httpdocs/.htaccess
+++ b/httpdocs/.htaccess
@@ -1,3 +1,15 @@
+SetOutputFilter DEFLATE
+AddOutputFilterByType DEFLATE "application/atom+xml" "application/javascript" "application/json" "application/ld+json" "application/manifest+json" "application/rdf+xml" "application/rss+xml" "application/schema+json" "application/vnd.geo+json" "application/vnd.ms-fontobject" "application/x-font-ttf" "application/x-javascript" "application/x-web-app-manifest+json" "application/xhtml+xml" "application/xml" "font/eot" "font/opentype" "image/bmp" "image/svg+xml" "image/vnd.microsoft.icon" "image/x-icon" "text/cache-manifest" "text/css" "text/html" "text/javascript" "text/plain" "text/vcard" "text/vnd.rim.location.xloc" "text/vtt" "text/x-component" "text/x-cross-domain-policy" "text/xml"
+
+# SECTION BEGIN GIT PROTECTION
+RedirectMatch 404 /\.git
+# SECTION END GIT PROTECTION
+
+<IfModule mod_headers.c>
+    Header set X-Content-Type-Options nosniff
+    Header always append X-Frame-Options "DENY"
+</IfModule>
+
 <ifModule mod_rewrite.c>
   RewriteEngine On
   RewriteBase /

--- a/httpdocs/404.php
+++ b/httpdocs/404.php
@@ -7,5 +7,9 @@ elseif (in_array($uri, array('/settings', '/scene', '/animation', '/demo', '/ser
 else
   $found = false;
 http_response_code($found ? 200 : 404);
+
+header("X-Content-Type-Options: nosniff");
+header("X-Frame-Options: DENY");
+
 readfile('index.html');
 ?>


### PR DESCRIPTION
Merge of the two `.htaccess` files. As the first one is not on this repo, I will put a copy below such that you can ensure that the merge is correct:
```
SetOutputFilter DEFLATE
AddOutputFilterByType DEFLATE "application/atom+xml" "application/javascript" "application/json" "application/ld+json" "application/manifest+json" "application/rdf+xml" "application/rss+xml" "application/schema+json" "application/vnd.geo+json" "application/vnd.ms-fontobject" "application/x-font-ttf" "application/x-javascript" "application/x-web-app-manifest+json" "application/xhtml+xml" "application/xml" "font/eot" "font/opentype" "image/bmp" "image/svg+xml" "image/vnd.microsoft.icon" "image/x-icon" "text/cache-manifest" "text/css" "text/html" "text/javascript" "text/plain" "text/vcard" "text/vnd.rim.location.xloc" "text/vtt" "text/x-component" "text/x-cross-domain-policy" "text/xml"

# SECTION BEGIN GIT PROTECTION
RedirectMatch 404 /\.git
# SECTION END GIT PROTECTION

RewriteEngine On
RewriteCond %{HTTPS} !=on
RewriteRule (.*) https://webots.cloud/$1 [R=301,L]
```

I also added two headers rules both in the `.htaccess` and in the `404.php` to improve security.