### PR TITLE
Fix server page load error

### DIFF
--- a/httpdocs/js/webots-cloud.js
+++ b/httpdocs/js/webots-cloud.js
@@ -605,7 +605,8 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function initSearch(searchString) {
-      document.getElementById(activeTab + '-search-input').value = searchString;
+      if (activeTab !== 'server')
+        document.getElementById(activeTab + '-search-input').value = searchString;
       for (let type of ['scene', 'animation', 'simulation']) {
         document.getElementById(type + '-search-input').addEventListener('keyup', function(event) {
           if (!getSearch('delay')) {


### PR DESCRIPTION
When loading the https://webots.cloud/server page: the first `activeTab` is 'server' and there is no search input, so the value does not exist and causes an error.