### PR TITLE
Fix back button

### DIFF
--- a/httpdocs/js/project.js
+++ b/httpdocs/js/project.js
@@ -55,7 +55,7 @@ export default class Project extends User {
             pushUrl = url.pathname + url.hash;
           }
           if (pushHistory)
-            window.history.pushState(null, name, pushUrl);
+            window.history.pushState(null, '', pushUrl);
           if (data.error) { // no such animation
             that.notFound();
             resolve();

--- a/httpdocs/js/project.js
+++ b/httpdocs/js/project.js
@@ -6,7 +6,7 @@ export default class Project extends User {
   constructor(title, footer, routes) {
     super(title, footer, routes);
     this.termsOfService = new TermsAndPrivacy(routes, this);
-    this.load();
+    this.load(null, false);
   }
   static run(title, footer, routes) {
     Project.current = new Project(title, footer, routes);

--- a/httpdocs/js/router.js
+++ b/httpdocs/js/router.js
@@ -29,7 +29,7 @@ export default class Router {
       }
     });
     window.onpopstate = function(event) {
-      that.load(document.location.pathname + document.location.hash, false);
+      that.load(document.location.pathname + document.location.search + document.location.hash, false);
       event.preventDefault();
     };
   }
@@ -86,7 +86,7 @@ export default class Router {
           const route = that.routes[i];
           if (url.pathname === route.url) {
             if (pushHistory)
-              window.history.pushState(null, name, url.pathname + url.search + url.hash);
+              window.history.pushState(null, '', url.pathname + url.search + url.hash);
             route.setup(that);
             found = true;
             resolve();
@@ -107,7 +107,7 @@ export default class Router {
     let promise = new Promise((resolve, reject) => {
       that.notFound();
       if (pushHistory)
-        window.history.pushState(null, name, url.pathname + url.search + url.hash);
+        window.history.pushState(null, '', url.pathname + url.search + url.hash);
       resolve();
     });
     return promise;
@@ -115,7 +115,7 @@ export default class Router {
   notFound() {
     const pathname = window.location.pathname;
     const url = window.location.origin + pathname;
-    window.history.pushState(null, '404 Not Found', url);
+    window.history.pushState(null, '', url);
     const hostname = document.location.hostname;
     let template = document.createElement('template');
     template.innerHTML =

--- a/httpdocs/js/webots-cloud.js
+++ b/httpdocs/js/webots-cloud.js
@@ -656,7 +656,7 @@ document.addEventListener('DOMContentLoaded', function() {
           if (getSearch(activeTab) && getSearch(activeTab) !== '')
             url.searchParams.append('search', getSearch(activeTab));
           updateSearchIcon(activeTab);
-          window.history.pushState(activeTab, document.title, (url.pathname + url.search).toString());
+          window.history.pushState(null, '', (url.pathname + url.search).toString());
           document.head.querySelector('#title').innerHTML = 'webots.cloud - ' + activeTab;
           CONTENT.forEach((item) => {
             if (item && item.classList.contains(ACTIVE_CLASS))
@@ -679,7 +679,7 @@ document.addEventListener('DOMContentLoaded', function() {
         url.searchParams.append('sort', getSort(type));
       if (getSearch(type) && getSearch(type) !== '')
         url.searchParams.append('search', getSearch(type));
-      window.history.replaceState('search', '', (url.pathname + url.search).toString());
+      window.history.replaceState(null, '', (url.pathname + url.search).toString());
 
       if (type === 'scene')
         listAnimations('S', scenePage, getSort(type), getSearch(type));


### PR DESCRIPTION
Fixes #35.
We can now view this [link](https://testing.webots.cloud/run?version=R2022b&url=https://github.com/omichel/panda/blob/main/worlds/panda.wbt) and come straight back here when clicking back on the browser after playing the simulation.

However, each reset is pushed to the `history`, therefore the back button needs to be clicked as many times as the user has reset the simulation. This might be a fix that needs to be done on the `webots js` side.