### PR TITLE
Redirect `add your own server` to correct doc

### DIFF
--- a/httpdocs/js/webots-cloud.js
+++ b/httpdocs/js/webots-cloud.js
@@ -556,7 +556,7 @@ document.addEventListener('DOMContentLoaded', function() {
             </nav>
             <div class="container is-fullhd">
               <div class="buttons">
-                <button class="button" onclick="window.open('https://github.com/cyberbotics/webots-cloud/wiki')">
+                <button class="button" onclick="window.open('https://www.cyberbotics.com/doc/guide/web-server')">
                   Add your own server</button>
               </div>
             </div>


### PR DESCRIPTION
For now the new link will not work except if you specify the version: https://www.cyberbotics.com/doc/guide/web-server?version=master

So either we accept that it does not work for some days or we merge this PR after the release