### PR TITLE
Update webots-cloud.js

### DIFF
--- a/httpdocs/ajax/animation/create.php
+++ b/httpdocs/ajax/animation/create.php
@@ -57,18 +57,15 @@
 
   // connect to database
   require '../../../php/database.php';
+  header('Content-Type: application/json');
   $mysqli = new mysqli($database_host, $database_username, $database_password, $database_name);
   if ($mysqli->connect_errno)
     error("Can't connect to MySQL database: $mysqli->connect_error");
   $mysqli->set_charset('utf8');
 
   // check if uploading is done
-  header('Content-Type: application/json');
-  $json = file_get_contents('php://input');
-  $data = json_decode($json);
-  $uploading = (isset($data->uploading)) ? intval($data->uploading) : 1;
-  $uploadId = (isset($data->uploadId)) ? intval($data->uploadId) : null;
-  if (!$uploading && $uploadId) {
+  if (isset($_POST['uploadId']) {
+    $uploadId = intval($_POST['uploadId']);
     $query = "UPDATE animation SET uploading=0 WHERE id=$uploadId";
     $mysqli->query($query) or error($mysqli->error);
     die('{"status": "uploaded"}');

--- a/httpdocs/ajax/animation/create.php
+++ b/httpdocs/ajax/animation/create.php
@@ -64,7 +64,7 @@
   $mysqli->set_charset('utf8');
 
   // check if uploading is done
-  if (isset($_POST['uploadId']) {
+  if (isset($_POST['uploadId'])) {
     $uploadId = intval($_POST['uploadId']);
     $query = "UPDATE animation SET uploading=0 WHERE id=$uploadId";
     $mysqli->query($query) or error($mysqli->error);

--- a/httpdocs/js/webots-cloud.js
+++ b/httpdocs/js/webots-cloud.js
@@ -843,7 +843,6 @@ document.addEventListener('DOMContentLoaded', function() {
         event.preventDefault();
         modal.querySelector('button[type="submit"]').classList.add('is-loading');
         let body = new FormData(modal.querySelector('form'));
-        body.append('type', type);
         body.append('user', project.id);
         body.append('password', project.password);
         fetch('/ajax/animation/create.php', {method: 'post', body: body})
@@ -856,7 +855,9 @@ document.addEventListener('DOMContentLoaded', function() {
             else if (!cancelled) {
               const id = data.id;
               const total = data.total;
-              fetch('/ajax/animation/create.php', {method: 'post', body: JSON.stringify({uploading: 0, uploadId: id})})
+              let uploading = new FormData();
+              uploading.append('uploadId', id);
+              fetch('/ajax/animation/create.php', {method: 'post', body: uploading})
                 .then(function(response) {
                   return response.json();
                 })


### PR DESCRIPTION
This PR fixes a bug introduced in #25 while attempting to load large animation files:
`ajax/animation/create.php:67: $json = file_get_contents('php://input');
Allowed memory size of 671088640 bytes exhausted (tried to allocate 335249440 bytes)`

It also removes a unused `type` parameter and fixes the declaration of the header (which was missing in case of MySQL connection error).
