### PR TITLE
Fix unique url

### DIFF
--- a/database/webots-cloud.sql
+++ b/database/webots-cloud.sql
@@ -49,7 +49,7 @@ CREATE TABLE `project` (
 
 ALTER TABLE `project`
   ADD PRIMARY KEY (`id`),
-  ADD UNIQUE KEY `url` (`url`),
+  ADD UNIQUE KEY `url_branch` (`url`,`branch`);
   MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 CREATE TABLE `user` (


### PR DESCRIPTION
Now that database rows depends on the branch (main, beta, ...) we should allow several rows to have the same `url` as long as they do not have the same pair of (`url`, `branch`)