### PR TITLE
Workflow queue

### DIFF
--- a/database/webots-cloud.sql
+++ b/database/webots-cloud.sql
@@ -88,4 +88,7 @@ CREATE TABLE `queue` (
   `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+ALTER TABLE `queue`
+  ADD UNIQUE KEY `project` (`project`,`participant`);
+
 COMMIT;

--- a/database/webots-cloud.sql
+++ b/database/webots-cloud.sql
@@ -4,12 +4,12 @@ CREATE TABLE `animation` (
   `uploaded` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `title` varchar(256) NOT NULL,
   `description` varchar(2048) NOT NULL,
-  `version` varchar(16) NOT NULL,
+  `version` varchar(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
   `duration` int(11) NOT NULL,
   `size` int(11) NOT NULL,
   `viewed` int(11) NOT NULL DEFAULT '0',
   `user` int(11) NOT NULL,
-  `branch` varchar(256) NOT NULL DEFAULT 'main',
+  `branch` varchar(256) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT 'main',
   `uploading` bit(1) DEFAULT b'1'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -39,9 +39,9 @@ CREATE TABLE `project` (
   `stars` int(11) NOT NULL,
   `title` varchar(256) NOT NULL,
   `description` varchar(2048) NOT NULL,
-  `version` varchar(16) NOT NULL,
-  `type` enum('demo','competition') NOT NULL,
-  `branch` varchar(256) CHARACTER SET utf8 NOT NULL DEFAULT 'main',
+  `version` varchar(16) CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  `type` enum('demo','competition') CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
+  `branch` varchar(256) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT 'main',
   `participants` int(11) NOT NULL,
   `updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `viewed` int(11) NOT NULL
@@ -76,7 +76,7 @@ ALTER TABLE `repository`
 
 CREATE TABLE `server_branch` (
   `id` int(11) NOT NULL,
-  `branch` varchar(256) NOT NULL DEFAULT 'main'
+  `branch` varchar(256) CHARACTER SET ascii COLLATE ascii_bin NOT NULL DEFAULT 'main'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 ALTER TABLE `server_branch`
@@ -84,7 +84,7 @@ ALTER TABLE `server_branch`
 
 CREATE TABLE `queue` (
   `project` int(11) NOT NULL,
-  `participant` varchar(2048) NOT NULL,
+  `participant` varchar(2048)  CHARACTER SET ascii COLLATE ascii_bin NOT NULL,
   `date` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/httpdocs/run_competition.php
+++ b/httpdocs/run_competition.php
@@ -141,7 +141,7 @@ $mysqli->query($query) or die($mysqli->error);
 
 if ($total == 0)
   repository_dispatch($organizer, $participant);
-elseif $mysqli->affected_rows == 1
+elseif ($mysqli->affected_rows == 1)
   die("Success: job added to the repository dispatch queue.");
 else
   die("Success: job already in the repository dispatch queue.");


### PR DESCRIPTION
This PR implements a workflow queue for each competition to avoid a git conflict in the `participants.txt` file in case two competition workflows are running in parallel.

The [run workflow](https://github.com/cyberbotics/competition-template/blob/112ce269a2c97fa11be7f5300b7868c88e9e2b26/.github/workflows/run.yml#L61-L64) of the competition template was updated to notify webots.cloud when the job is complete and the queue item can be released, and a new job can possibly start.