### PR TITLE
add demo category in competition participant

### DIFF
--- a/httpdocs/js/webots-cloud.js
+++ b/httpdocs/js/webots-cloud.js
@@ -1442,6 +1442,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 .then(function (participants) {
                   function getFlag(countryCode) {
                     const country = countryCode.toLowerCase();
+                    if (country == 'demo') {
+                      return '<span style="font-size:small">demo</span>';
+                    }
                     if (country.length != 2 || country == 'ru')
                       return `<svg width="32" height="24">
                               <rect width="32" height="24" fill="#fff" style="stroke-width:1;stroke:rgb(0,0,0)" />
@@ -1458,13 +1461,17 @@ document.addEventListener('DOMContentLoaded', function () {
                       `<td style="vertical-align:middle;" class="has-text-centered">${participant.performance}</td>`;
                     const link = participant.private ? `${participant.name}` :
                       `<a href="https://github.com/${participant.repository}" target="_blank">${participant.name}</a>`;
-                    const button = (metric == 'ranking' && ranking == 1) ? `<span style="font-size:x-large">&#127942;</span>` :
+                    const button = (metric == 'ranking' && ranking == 1) ?
+                      `<span style="font-size:x-large">&#127942;</span>` :
                       `<button class="button is-small is-primary" style="background-color: #007acc;"` +
                       `id="${participant.id}-view">View</button>`;
+                    const flag = participant.repository.startsWith('cyberbotics/') ?
+                      '<span style="font-size:small">demo</span>' :
+                      getFlag(participant.country);
                     tableContent.innerHTML = `<tr>
                     <td style="vertical-align:middle;" class="has-text-centered">${ranking}</td>
                     <td style="vertical-align:middle;font-size:x-large" class="has-text-centered"
-                     title="${participant.country}">${getFlag(participant.country)}</td>
+                     title="${participant.country}">${flag}</td>
                     <td style="vertical-align:middle;" title="${participant.description}">${link}</td>
                     ${performanceLine}
                     <td style="vertical-align:middle;" class="has-text-centered">${date}</td>

--- a/httpdocs/js/webots-cloud.js
+++ b/httpdocs/js/webots-cloud.js
@@ -1442,9 +1442,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 .then(function (participants) {
                   function getFlag(countryCode) {
                     const country = countryCode.toLowerCase();
-                    if (country == 'demo') {
-                      return '<span style="font-size:small">demo</span>';
-                    }
                     if (country.length != 2 || country == 'ru')
                       return `<svg width="32" height="24">
                               <rect width="32" height="24" fill="#fff" style="stroke-width:1;stroke:rgb(0,0,0)" />
@@ -1465,7 +1462,7 @@ document.addEventListener('DOMContentLoaded', function () {
                       `<span style="font-size:x-large">&#127942;</span>` :
                       `<button class="button is-small is-primary" style="background-color: #007acc;"` +
                       `id="${participant.id}-view">View</button>`;
-                    const flag = participant.repository.startsWith('cyberbotics/') ?
+                    const flag = participant.repository.startsWith(`${username}/`) ?
                       '<span style="font-size:small">demo</span>' :
                       getFlag(participant.country);
                     tableContent.innerHTML = `<tr>

--- a/httpdocs/js/webots-cloud.js
+++ b/httpdocs/js/webots-cloud.js
@@ -1528,7 +1528,7 @@ document.addEventListener('DOMContentLoaded', function () {
         `<div class="field">
           <p style="padding-bottom:15px;">
            To register, you will need to create your own robot controller on GitHub.
-           Follow the instructions on the <a href="${project.competitionUrl.split('/blob')[0]}">repository of the competition organizer</a>.
+           Follow the instructions on the <a href="${project.competitionUrl.split('/blob')[0]}#readme">repository of the competition organizer</a>.
           </p>
         </div>`;
       ModalDialog.run(`Register to the competition`, content.innerHTML);

--- a/httpdocs/storage/.gitignore
+++ b/httpdocs/storage/.gitignore
@@ -1,0 +1,3 @@
+*
+!/.gitignore
+!/README.md


### PR DESCRIPTION
Add a special category for participants coming from the same GitHub account as the organizer. In this case the country is ignored and a "demo" label is displayed instead.
This PR also add a `.gitignore` file to the storage folder which is useful when checking the git status on the server.