### PR TITLE
Fix title that are too long

### DIFF
--- a/httpdocs/css/webots-cloud.css
+++ b/httpdocs/css/webots-cloud.css
@@ -628,6 +628,7 @@ nav.pagination>a {
   border-right: #f0f0f0 solid 1px;
   border-left: #f0f0f0 solid 1px;
   box-shadow: 5px 5px 5px 0 #ddd;
+  overflow: hidden;
 }
 
 .result-version {


### PR DESCRIPTION
When the title of a proto is too long, it should be cut (the user is still able to see the full name via the tooltip).
However, we were missing a css line.

(If you want to see the wrong behavior, search for the `ResidentialBuildingWithRoundFront`)